### PR TITLE
Update .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 # vim: ft=sh
 
 # The S64 DA image to use
-S64_DA_VERSION=2.1.0
+S64_DA_VERSION=3.0.0
 
 # The port where S64 DA listens on
 DB_PORT_S64DA=5432
@@ -13,12 +13,15 @@ DATA_S64DA=/mnt/path/to/s64da-data
 PSQL_VERSION=11
 
 # The port where PSQL listens on. Note: if you want to run both databases side-
-# by-side, the ports need to be different.
+# by-side, the ports need to be different
 DB_PORT_PSQL=5432
 
 # Path to database storage for PSQL
 DATA_PSQL=/mnt/path/to/pg-data
 
-# The Xilinx device IDs, please match to your system configuration
+# The Xilinx device IDs, please match to your system configuration if applicable.
+# Please ignore these settings if you are not using Xilinx FPGAs
+# Device information for XCL_MGMT_ID can be collected with: ls /dev/xclmgmt*
 XCL_MGMT_ID=1280
+# Device information for DRI_RENDER_ID can be collected with: ls /dev/dri/renderD*
 DRI_RENDER_ID=128


### PR DESCRIPTION
Bump S64DA version to 3.0.0 and clarify use of Xilinx devices IDs